### PR TITLE
Fix np.clip broadcasting when outputs expand

### DIFF
--- a/docs/source/release/0.61.2-notes.rst
+++ b/docs/source/release/0.61.2-notes.rst
@@ -61,6 +61,21 @@ target specific. This is now rectified and refactored so as to provide a
 
 (`PR-#9972 <https://github.com/numba/numba/pull/9972>`__)
 
+Correct ``np.clip`` broadcasting for expanded outputs
+----------------------------------------------------
+
+Broadcasted clipping could incorrectly allocate the output array based on the
+input's shape, leading to shape mismatches when the broadcast result was larger.
+The allocation now uses the broadcasted shape so that calls such as:
+
+.. code-block:: python
+
+   np.clip(np.array([[1], [2]]), a_min=0, a_max=np.array([3, 4, 5]))
+
+produce arrays of shape ``(2, 3)`` as in NumPy.
+
+(`PR-#9991 <https://github.com/numba/numba/issues/9991>`__)
+
 Pull-Requests:
 
 * PR `#9919 <https://github.com/numba/numba/pull/9919>`_: Support for NumPy 2.2 (`kc611 <https://github.com/kc611>`__)

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -2342,8 +2342,8 @@ def array_flatten(context, builder, sig, args):
 @register_jitable
 def _np_clip_impl(a, a_min, a_max, out):
     # Both a_min and a_max are numpy arrays
-    ret = np.empty_like(a) if out is None else out
     a_b, a_min_b, a_max_b = np.broadcast_arrays(a, a_min, a_max)
+    ret = np.empty_like(a_b) if out is None else out
     for index in np.ndindex(a_b.shape):
         val_a = a_b[index]
         val_a_min = a_min_b[index]
@@ -2464,16 +2464,16 @@ def np_clip(a, a_min, a_max, out=None):
         if a_min_is_none:
             def np_clip_na(a, a_min, a_max, out=None):
                 # a_max is a numpy array but a_min is None
-                ret = np.empty_like(a) if out is None else out
                 a_b, a_max_b = np.broadcast_arrays(a, a_max)
+                ret = np.empty_like(a_b) if out is None else out
                 return _np_clip_impl_none(a_b, a_max_b, True, ret)
 
             return np_clip_na
         elif a_max_is_none:
             def np_clip_an(a, a_min, a_max, out=None):
                 # a_min is a numpy array but a_max is None
-                ret = np.empty_like(a) if out is None else out
                 a_b, a_min_b = np.broadcast_arrays(a, a_min)
+                ret = np.empty_like(a_b) if out is None else out
                 return _np_clip_impl_none(a_b, a_min_b, False, ret)
 
             return np_clip_an

--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -1752,6 +1752,25 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
             with self.assertRaisesRegex(ValueError, msg):
                 cfunc(a, a_min, a_max)
 
+    def test_clip_broadcast_expand(self):
+        has_out = (np_clip, np_clip_kwargs, array_clip, array_clip_kwargs)
+        has_no_out = (np_clip_no_out, array_clip_no_out)
+        a = np.array([[1], [2]])
+        a_max = np.array([3, 4, 5])
+        a_min = 0
+        for pyfunc in has_out + has_no_out:
+            cfunc = jit(nopython=True)(pyfunc)
+            expected = pyfunc(a, a_min, a_max)
+            got = cfunc(a, a_min, a_max)
+            np.testing.assert_equal(expected, got)
+
+            if pyfunc in has_out:
+                pyout = np.empty_like(expected)
+                cout = np.empty_like(expected)
+                np.testing.assert_equal(pyfunc(a, a_min, a_max, pyout),
+                                        cfunc(a, a_min, a_max, cout))
+                np.testing.assert_equal(pyout, cout)
+
     def test_conj(self):
         for pyfunc in [array_conj, array_conjugate]:
             cfunc = jit(nopython=True)(pyfunc)


### PR DESCRIPTION
## Summary
- allocate output arrays after broadcasting in `_np_clip_impl`
- fix broadcasting allocation for `np_clip_na`/`np_clip_an`
- add regression test for broadcasting to a larger array
- document the fix in the 0.61.2 release notes

## Testing
- `pre-commit run --files numba/np/arrayobj.py numba/tests/test_array_methods.py docs/source/release/0.61.2-notes.rst`
- `pytest numba/tests/test_array_methods.py::TestArrayMethods::test_clip_broadcast_expand -vv` *(fails: Numba could not be imported)*

------
https://chatgpt.com/codex/tasks/task_e_6847c71155048332980e61968d255eee