### PR TITLE
gha/replace conda installation of llvmlite with pip

### DIFF
--- a/.github/workflows/numba_osx-64_wheel_builder.yml
+++ b/.github/workflows/numba_osx-64_wheel_builder.yml
@@ -20,7 +20,6 @@ concurrency:
 env:
   ARTIFACT_RETENTION_DAYS: 7
   WHEELS_INDEX_URL: https://pypi.anaconda.org/numba/label/dev/simple
-  CONDA_CHANNEL_NUMBA: numba/label/dev
 
 jobs:
   load-matrix:
@@ -95,7 +94,7 @@ jobs:
           if [ "${{ inputs.llvmlite_wheel_runid }}" != "" ]; then
               python -m pip install llvmlite_wheels/*.whl
           else
-              conda install -c ${{ env.CONDA_CHANNEL_NUMBA }} llvmlite
+              python -m pip install -i ${{ env.WHEELS_INDEX_URL }} llvmlite
           fi
           conda install -c defaults python-build numpy==${{ matrix.numpy_build }} clang_osx-64 clangxx_osx-64
           conda install --yes llvm-openmp
@@ -185,7 +184,7 @@ jobs:
           if [ "${{ inputs.llvmlite_wheel_runid }}" != "" ]; then
               $PYTHON_PATH -m pip install llvmlite_wheels/*.whl
           else
-              $PYTHON_PATH -m pip install -i $WHEELS_INDEX_URL llvmlite
+              $PYTHON_PATH -m pip install -i ${{ env.WHEELS_INDEX_URL }} llvmlite
           fi
           $PYTHON_PATH -m twine check dist/*.whl
           $PYTHON_PATH -m pip install dist/numba*.whl numpy==${{ matrix.numpy_test }}

--- a/.github/workflows/numba_osx-arm64_wheel_builder.yml
+++ b/.github/workflows/numba_osx-arm64_wheel_builder.yml
@@ -20,7 +20,6 @@ concurrency:
 env:
   ARTIFACT_RETENTION_DAYS: 7
   WHEELS_INDEX_URL: https://pypi.anaconda.org/numba/label/dev/simple
-  CONDA_CHANNEL_NUMBA: numba/label/dev
 
 jobs:
   load-matrix:
@@ -91,7 +90,7 @@ jobs:
           if [ "${{ inputs.llvmlite_wheel_runid }}" != "" ]; then
               arch -arm64 python -m pip install llvmlite_wheels/*.whl
           else
-              conda install -c ${{ env.CONDA_CHANNEL_NUMBA }} llvmlite
+              arch -arm64 python -m pip install -i ${{ env.WHEELS_INDEX_URL }} llvmlite
           fi
           conda install -c defaults python-build numpy==${{ matrix.numpy_build }} clang_osx-arm64 clangxx_osx-arm64
           conda install --yes llvm-openmp
@@ -191,7 +190,7 @@ jobs:
           if [ "${{ inputs.llvmlite_wheel_runid }}" != "" ]; then
               arch -arm64 python -m pip install llvmlite_wheels/*.whl
           else
-              arch -arm64 python -m pip install -i $WHEELS_INDEX_URL llvmlite
+              arch -arm64 python -m pip install -i ${{ env.WHEELS_INDEX_URL }} llvmlite
           fi
           arch -arm64 python -m twine check dist/*.whl
           arch -arm64 python -m pip install dist/numba*.whl numpy==${{ matrix.numpy_test }}

--- a/.github/workflows/numba_win-64_wheel_builder.yml
+++ b/.github/workflows/numba_win-64_wheel_builder.yml
@@ -18,7 +18,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CONDA_CHANNEL_NUMBA: numba/label/dev
   ARTIFACT_RETENTION_DAYS: 7
   WHEELS_INDEX_URL: https://pypi.anaconda.org/numba/label/dev/simple
 
@@ -91,7 +90,7 @@ jobs:
           if [ "${{ inputs.llvmlite_wheel_runid }}" != "" ]; then
               python -m pip install llvmlite_wheels/*.whl
           else
-              conda install -c ${{ env.CONDA_CHANNEL_NUMBA }} llvmlite
+              python -m pip install -i ${{ env.WHEELS_INDEX_URL }} llvmlite
           fi
           conda install -c defaults python-build numpy==${{ matrix.numpy_build }} setuptools
           python -m pip install tbb==2021.6 tbb-devel==2021.6
@@ -149,7 +148,7 @@ jobs:
           if [ "${{ inputs.llvmlite_wheel_runid }}" != "" ]; then
               python -m pip install llvmlite_wheels/*.whl
           else
-              python -m pip install -i $WHEELS_INDEX_URL llvmlite
+              python -m pip install -i ${{ env.WHEELS_INDEX_URL }} llvmlite
           fi
           python -m twine check dist/*.whl
           python -m pip install dist/*.whl


### PR DESCRIPTION
For numba wheels build step, 
replace conda install to pip install llvmlite using WHEELS_INDEX_URL
`https://pypi.anaconda.org/numba/label/dev/simple`
The test step already uses this.